### PR TITLE
Allow more than one image per GPU during evaluation

### DIFF
--- a/maskrcnn_benchmark/config/paths_catalog.py
+++ b/maskrcnn_benchmark/config/paths_catalog.py
@@ -7,6 +7,14 @@ import os
 class DatasetCatalog(object):
     DATA_DIR = "datasets"
     DATASETS = {
+        "coco_2017_train": (
+            "coco/train2017",
+            "coco/annotations/instances_train2017.json"
+        ),
+        "coco_2017_val": (
+            "coco/val2017",
+            "coco/annotations/instances_val2017.json"
+        ),
         "coco_2014_train": (
             "coco/train2014",
             "coco/annotations/instances_train2014.json",

--- a/maskrcnn_benchmark/modeling/roi_heads/mask_head/mask_head.py
+++ b/maskrcnn_benchmark/modeling/roi_heads/mask_head/mask_head.py
@@ -76,7 +76,12 @@ class ROIMaskHead(torch.nn.Module):
         if self.cfg.MODEL.MASKIOU_ON: 
             if not self.training:
                 result = self.post_processor(mask_logits, proposals)
-                return x, result, {}, roi_feature, result[0].get_field("mask"), result[0].get_field("labels"), None
+                # merge `selected_mask` and `labels` as tensors
+                selected_mask = [r.get_field("mask") for r in result]
+                selected_mask = torch.cat(selected_mask)
+                labels = [r.get_field("labels") for r in result]
+                labels = torch.cat(labels)
+                return x, result, {}, roi_feature, selected_mask, labels, None
 
             loss_mask, selected_mask, labels, maskiou_targets = self.loss_evaluator(proposals, mask_logits, targets)
             return x, all_proposals, dict(loss_mask=loss_mask), roi_feature, selected_mask, labels, maskiou_targets

--- a/maskrcnn_benchmark/modeling/roi_heads/maskiou_head/inference.py
+++ b/maskrcnn_benchmark/modeling/roi_heads/maskiou_head/inference.py
@@ -22,7 +22,9 @@ class MaskIoUPostProcessor(nn.Module):
         num_masks = pred_maskiou.shape[0]
         index = torch.arange(num_masks, device=labels.device)
         maskious = pred_maskiou[index, labels]
-        maskious = [maskious]
+        # split `maskiou` accroding to `boxes`
+        boxes_per_image = [len(box) for box in boxes]
+        maskious = maskious.split(boxes_per_image, dim=0)
         results = []
         for maskiou, box in zip(maskious, boxes):
             bbox = BoxList(box.bbox, box.size, mode="xyxy")

--- a/maskrcnn_benchmark/utils/model_zoo.py
+++ b/maskrcnn_benchmark/utils/model_zoo.py
@@ -2,9 +2,14 @@
 import os
 import sys
 
-from torch.utils.model_zoo import _download_url_to_file
-from torch.utils.model_zoo import urlparse
-from torch.utils.model_zoo import HASH_REGEX
+try:
+    from torch.hub import _download_url_to_file
+    from torch.hub import urlparse
+    from torch.hub import HASH_REGEX
+except ImportError:
+    from torch.utils.model_zoo import _download_url_to_file
+    from torch.utils.model_zoo import urlparse
+    from torch.utils.model_zoo import HASH_REGEX
 
 from maskrcnn_benchmark.utils.comm import is_main_process
 from maskrcnn_benchmark.utils.comm import synchronize


### PR DESCRIPTION
- It allows muti-images for one GPU during the testing time, which was metioned in https://github.com/zjhuang22/maskscoring_rcnn/issues/7. 
I have only checked ResNet-50-FPN-MS-RCNN on `coco_2017_val` via single GPU. Note that `MODEL.RPN.FPN_POST_NMS_TOP_N_TEST` also needs to be changed, see [here](https://github.com/facebookresearch/maskrcnn-benchmark/issues/672) for more details. 
- I also modify [model_zoo.py](https://github.com/Maktu6/maskscoring_rcnn/blob/master/maskrcnn_benchmark/utils/model_zoo.py#L5-L9) which would raise an `ImportError` in PyTorch 1.1 and update [paths_catalog.py](https://github.com/Maktu6/maskscoring_rcnn/blob/master/maskrcnn_benchmark/config/paths_catalog.py#L10-L17) to support `coco 2017`. 
```bash
python tools/test_net.py --config-file "configs/e2e_ms_rcnn_R_50_FPN_1x.yaml" \
                                       TEST.IMS_PER_BATCH 5 \
                                       MODEL.RPN.FPN_POST_NMS_TOP_N_TEST 5000 \
                                       MODEL.WEIGHT pretrained_models/res50-model_0090000.pth \
                                       DATASETS.TEST "('coco_2017_val',)" 
```
The following are the evaluation results which are the same as [yours](https://github.com/zjhuang22/maskscoring_rcnn/blob/master/README.md#results):
```
Running per image evaluation...
Evaluate annotation type *bbox*
DONE (t=45.91s).
Accumulating evaluation results...
DONE (t=5.32s).
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.379
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.593
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.411
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.222
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.408
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.497
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.312
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.491
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.516
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.329
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.549
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.644

Running per image evaluation...
Evaluate annotation type *segm*
DONE (t=51.75s).
Accumulating evaluation results...
DONE (t=5.53s).
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.356
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.561
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.382
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.166
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.378
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.519
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.297
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.453
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.471
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.275
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.505
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.617
```